### PR TITLE
Add error message for exit code 2

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -17,4 +17,12 @@ $packageArgs = @{
   validExitCodes= @(0)
 }
 
-Install-ChocolateyPackage @packageArgs
+try {
+  Install-ChocolateyPackage @packageArgs
+} catch  {
+  if($_.Exception.Message -match "Exit code was '2'") {
+    throw "The installer exited with code 2. This means LibreWolf is probably still running. Close LibreWolf and try again."
+  } else {
+    throw $_.Exception
+  }
+}


### PR DESCRIPTION
Throws a error and prints a message if the installer fails with exit code 2. In that case, LibreWolf is probably still open.

![Screenshot_20220119_194059](https://user-images.githubusercontent.com/48161361/150194252-20eccee8-57d0-40ce-8a92-c0ab4aeda382.png)
